### PR TITLE
add id field to the datapoints database

### DIFF
--- a/create.sql
+++ b/create.sql
@@ -19,6 +19,7 @@ CREATE TABLE habits (
 );
 
 CREATE TABLE datapoints (
+  id INTEGER PRIMARY KEY,
   login TEXT,
   habit TEXT,
   occasion TEXT,

--- a/frontend/global_vars.ts
+++ b/frontend/global_vars.ts
@@ -1,11 +1,10 @@
-// TODO: change the collection type to this and make sure the code uses it correctly:
 export type Collection = {
+  id: number,
   habit: string
   occasion: string
   datapoint: number
   comment: string
 }
-/*type Collection = [string, string, number, string];*/
 
 export var collection: Collection[] = [];
 export function updateCollection(x: Collection[]) {

--- a/main.py
+++ b/main.py
@@ -57,15 +57,16 @@ def get_user():
 def get_collection(user: str):
     con = get_db()
     cur = con.cursor()
-    j = cur.execute("SELECT habit, occasion, datapoint, comment FROM datapoints WHERE login = ?", (user,))
+    j = cur.execute("SELECT id, habit, occasion, datapoint, comment FROM datapoints WHERE login = ?", (user,))
     collection = j.fetchall()
     new_collection = []
     for i in collection:
         j = {
-            "habit": i[0],
-            "occasion": i[1],
-            "datapoint": i[2],
-            "comment": i[3]
+            "id": i[0],
+            "habit": i[1],
+            "occasion": i[2],
+            "datapoint": i[3],
+            "comment": i[4]
         }
         new_collection.append(j)
     print('old collection: ', collection)


### PR DESCRIPTION
I think it's a good idea to have some identifier that we can use to refer to datapoints. For example, when deleting them we can just specify the `id` instead of `(user,habit,occasion,comment)` tuple like it's done now:

https://github.com/thermobased/flask-webapp/blob/bc938fa015090d7f46bfcf661d026edc26875b90/main.py#L190

Instead, we could do something like `DELETE FROM datapoints WHERE id = ?`.

It can get useful again if we decide to allow changing datapoints, we can refer to them simply using the id, no need to pass 4 fields to refer to a datapoint.

Ivan